### PR TITLE
Fix refresh token verification

### DIFF
--- a/src/common/modules/token/services/token.service.ts
+++ b/src/common/modules/token/services/token.service.ts
@@ -61,8 +61,6 @@ export class TokenService implements ITokenService {
       email: VERIFY_TOKEN.email,
       tryGetIfExists: false,
     };
-
-    await this._jwtService.verifyAsync<AccessTokenPayloadDto>(EXISTING_TOKEN);
     const NEW_TOKEN: string = await this.getAccessToken(ACCESS_TOKEN_PAYLOAD);
 
     return NEW_TOKEN;


### PR DESCRIPTION
## Summary
- simplify refreshToken to avoid double JWT verification

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6703658c832685225e43c2dad854