### PR TITLE
Fix translation service to use request language

### DIFF
--- a/src/common/modules/translate/services/translate.service.ts
+++ b/src/common/modules/translate/services/translate.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { I18nService } from 'nestjs-i18n';
+import { I18nService, I18nContext } from 'nestjs-i18n';
 
 import { TranslateOptionsWithoutArgumentsDto } from '../dtos/translate.dto';
 
@@ -14,7 +14,9 @@ export class TranslateService {
   //#region Public Methods
 
   public async translateWithoutArguments(options: TranslateOptionsWithoutArgumentsDto): Promise<string> {
-    return this._i18n.translate(options.key, { lang: 'en' });
+    const context = I18nContext.current();
+    const LANG = context?.lang;
+    return this._i18n.translate(options.key, { lang: LANG });
   }
 
   //#endregion


### PR DESCRIPTION
## Summary
- ensure `TranslateService` picks up language from the current request context so translation works across the API

## Testing
- `npm test` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2a9991648326ba99c8a295b05b87